### PR TITLE
Support separate configuration of multicast logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ In your logger config, simply do something like this:
 
 ```elixir
 config :logger,
-        backends: [ :console, LoggerMulticastBackend ],
-        level: :debug,
-        format: "$time $metadata[$level] $message\n"
+        backends: [ :console, LoggerMulticastBackend ]
 ```
 
 or, at runtime, you can add this to your current config...
@@ -49,15 +47,13 @@ $ cell watch
 
 ## Custom Configuration
 
-Don't like the default multicast target or format? change it by replacing `LoggerMulticastBackend` in the above examples with a tuple including options something like this:
+Don't like the default multicast target or format? Change it by including options like this:
 
 ```elixir
-config :logger, backends: [
-  :console,
-  {LoggerMulticastBackend,
+  config :logger, :logger_multicast_backend,
     target: {{224,1,22,223}, 4252},
-    level:  :info}
-]
+    format: "$time $metadata[$level] $message\\n",
+    level:  :info
 ```
 
 The full range of custom configuration options in the tuple are as follows:

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,31 +3,8 @@
 use Mix.Config
 
 config :logger,
-  handle_otp_reports: :true,
-  backends: [
-    :console, 
-#    { LoggerMulticastBackend, target: {{224,0,0,224}, 9999} }
-  ],
-  level: :debug,
-  format: "$time $metadata[$level] $message\n"
+  backends: [ :console, LoggerMulticastBackend ]
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for third-
-# party users, it should be done in your mix.exs file.
-
-# Sample configuration:
-#
-#     config :logger, :console,
-#       level: :info,
-#       format: "$date $time [$level] $metadata$message\n",
-#       metadata: [:user_id]
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :logger, :logger_multicast_backend,
+  format: "$node $metadata[$level] $message\n"
+  #target: {{224,0,0,224}, 9999}


### PR DESCRIPTION
This adds support for separating the Logger and MulticastLoggerBackend
configurations so that you can do something like this:
```
config :logger, :logger_multicast_backend,
  target: {{224,0,0,224}, 9999}
```
Configuration by passing all parameters in a tuple to the logger is
still supported:
```
config :logger,
  backends: [ :console,
              {LoggerMulticastBackend,
               target: {{224,0,0,244}, 999},
               format: "$time $metadata[$level] $message\n"} ]
```
This latter configuration takes precedence over the separate configuration
in a similar way to the :console logger. 

This change also fixes something that may have been misleading to users.
The `format` option was being set on the main `:logger` configuration
where it has no effect. For it to work, it has to be set in the
multicast backend options.